### PR TITLE
Fix typos in homoglyph dict

### DIFF
--- a/characters_safetext.py
+++ b/characters_safetext.py
@@ -138,8 +138,8 @@ HOMOGLYPHS = {  # To quickly verify that these characters are not Latin, enter t
     "ARMENIAN_S": u"Տ",
 
     "ARMENIAN_2": u"Ձ",
-    "ARMENIAN_ALT_ 2": u"շ",
-    "ARMENIAN_3": u"3",
+    "ARMENIAN_ALT_2": u"շ",
+    "ARMENIAN_3": u"Յ",
     "ARMENIAN_4": u"վ",
 
     # Hebrew Characters


### PR DESCRIPTION
Armenian alt 2 had a space in it that may cause problems and the Armenian 3 was just a normal '3'.